### PR TITLE
Fixes for building on current systems.

### DIFF
--- a/source/boardtype_friendlyelec.c
+++ b/source/boardtype_friendlyelec.c
@@ -140,8 +140,11 @@ static int getAllwinnerBoardID(char* boardId, int boardIdMaxLen)
     FILE *f;
     int ret = -1;
 
-    if (!(f = fopen("/sys/class/sunxi_info/sys_info", "r"))) {
-        return -1;
+   if (!(f = fopen("/sys/class/sunxi_info/sys_info", "r"))) {
+        if (!(f = fopen("/etc/sys_info", "r"))) {
+            LOGE("open /sys/class/sunxi_info/sys_info failed, put information in /etc/sys_info");
+            return -1;
+        }
     }
 
     while (!feof(f)) {

--- a/source/common.h
+++ b/source/common.h
@@ -30,24 +30,29 @@ SOFTWARE.
 #define I2C          42
 #define PWM          43
 
-int gpio_mode;
-const int pin_to_gpio_rev1[27];
-const int pin_to_gpio_rev2[27];
-const int physToGpioR3 [64];
+#pragma once
+#ifndef COMMON
+#define COMMON
 
-const int (*pin_to_gpio)[64];
+extern int gpio_mode;
+extern const int pin_to_gpio_rev1[27];
+extern const int pin_to_gpio_rev2[27];
+extern const int physToGpioR3 [64];
 
-const int physToGpio_neo [64];
-const int physToGpio_m1 [64];
-const int physToGpio_duo [64];
+extern const int (*pin_to_gpio)[64];
+
+extern const int physToGpio_neo [64];
+extern const int physToGpio_m1 [64];
+extern const int physToGpio_duo [64];
 
 // const int pinTobcm_BP [64];
 // const int physToGpioR3 [64];
 
-int gpio_direction[64];
-int revision;
+extern int gpio_direction[64];
+extern int revision;
 
-int check_gpio_priv(void);
-int get_gpio_number(int channel, unsigned int *gpio);
-int setup_error;
-int module_setup;
+extern int check_gpio_priv(void);
+extern int get_gpio_number(int channel, unsigned int *gpio);
+extern int setup_error;
+extern int module_setup;
+#endif

--- a/source/constants.c
+++ b/source/constants.c
@@ -26,6 +26,25 @@ SOFTWARE.
 #include "c_gpio.h"
 #include "event_gpio.h"
 
+PyObject *high;
+PyObject *low;
+PyObject *input;
+PyObject *output;
+PyObject *pwm;
+PyObject *serial;
+PyObject *i2c;
+PyObject *spi;
+PyObject *unknown;
+PyObject *board;
+PyObject *bcm;
+PyObject *raw;
+PyObject *pud_off;
+PyObject *pud_up;
+PyObject *pud_down;
+PyObject *rising_edge;
+PyObject *falling_edge;
+PyObject *both_edge;
+
 void define_constants(PyObject *module)
 {
     high = Py_BuildValue("i", HIGH);

--- a/source/constants.h
+++ b/source/constants.h
@@ -19,27 +19,27 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
-
+#pragma once 
 #define PY_PUD_CONST_OFFSET 20
 #define PY_EVENT_CONST_OFFSET 30
 
-PyObject *high;
-PyObject *low;
-PyObject *input;
-PyObject *output;
-PyObject *pwm;
-PyObject *serial;
-PyObject *i2c;
-PyObject *spi;
-PyObject *unknown;
-PyObject *board;
-PyObject *bcm;
-PyObject *raw;
-PyObject *pud_off;
-PyObject *pud_up;
-PyObject *pud_down;
-PyObject *rising_edge;
-PyObject *falling_edge;
-PyObject *both_edge;
+extern PyObject *high;
+extern PyObject *low;
+extern PyObject *input;
+extern PyObject *output;
+extern PyObject *pwm;
+extern PyObject *serial;
+extern PyObject *i2c;
+extern PyObject *spi;
+extern PyObject *unknown;
+extern PyObject *board;
+extern PyObject *bcm;
+extern PyObject *raw;
+extern PyObject *pud_off;
+extern PyObject *pud_up;
+extern PyObject *pud_down;
+extern PyObject *rising_edge;
+extern PyObject *falling_edge;
+extern PyObject *both_edge;
 
 void define_constants(PyObject *module);

--- a/source/py_gpio.c
+++ b/source/py_gpio.c
@@ -32,6 +32,19 @@ SOFTWARE.
 static PyObject *npi_revision;
 static int gpio_warnings = 1;
 
+const int pin_to_gpio_rev1[27];
+const int pin_to_gpio_rev2[27];
+const int physToGpioR3 [64];
+
+const int (*pin_to_gpio)[64];
+
+
+// const int pinTobcm_BP [64];
+// const int physToGpioR3 [64];
+
+int gpio_direction[64];
+
+
 struct py_callback
 {
     unsigned int gpio;

--- a/source/py_pwm.h
+++ b/source/py_pwm.h
@@ -20,5 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-PyTypeObject PWMType;
+#pragma once 
+
+extern PyTypeObject PWMType;
 PyTypeObject *PWM_init_PWMType(void);

--- a/source/soft_pwm.c
+++ b/source/soft_pwm.c
@@ -25,7 +25,7 @@ SOFTWARE.
 #include <time.h>
 #include "c_gpio.h"
 #include "soft_pwm.h"
-pthread_t threads;
+static pthread_t threads;
 
 struct pwm
 {


### PR DESCRIPTION
I edited the source so that it builds correctly (issue #46 ) and implemented sunxi_info hack from https://forum.armbian.com/topic/5647-nanopi-neo-wiringnp-missing-sunxi_infosys_info/